### PR TITLE
Improve compiler errors, fix libb bug, allow shorter compiler flags.

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -299,7 +299,7 @@ static int subprocess(const char *arg0, const char *p_name, char *const *p_arg)
 // Parse a comment.
 // It starts with /* and finishes with */.
 //
-static void comment(struct compiler_args *args, FILE *in)
+static void comment(FILE *in)
 {
     int c;
 
@@ -321,6 +321,7 @@ static void comment(struct compiler_args *args, FILE *in)
 //
 static void whitespace(struct compiler_args *args, FILE *in)
 {
+    (void) args;
     int c;
 
     while ((c = fgetc(in)) != EOF) {
@@ -331,7 +332,7 @@ static void whitespace(struct compiler_args *args, FILE *in)
 
         if (c == '/') {
             if ((c = fgetc(in)) == '*') {
-                comment(args, in);
+                comment(in);
                 continue;
             }
             else {

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -107,6 +107,8 @@ struct stack_var {
 };
 
 static struct {
+    // TODO: 'whitespace' skips line before checking for semicolon,
+    // so displaying errors expecting semicolons may show wrong line.
     const char *file_name;
     unsigned long line;
 } compiler_pos;

--- a/src/compiler/main.c
+++ b/src/compiler/main.c
@@ -14,6 +14,7 @@ static inline void version(char *arg0)
     printf("%s " BCAUSE_VERSION "\n"
         "Copyright (C) 2022 Spydr06\n"
         "Copyright (C) 2025 sergev\n"
+        "Copyright (C) 2026 miublue\n"
         "This is free software; see the source for copying conditions.\n"
         "There is NO warranty.\n",
         arg0

--- a/src/compiler/main.c
+++ b/src/compiler/main.c
@@ -24,13 +24,13 @@ static inline void help(char *arg0)
 {
     printf("Usage: %s [options] file...\n"
         "Options:\n"
-        "--help      Display this information.\n"
-        "--version   Display compiler version information.\n"
-        "-o <file>   Place the output into <file>.\n"
-        "-L<dir>     Location of B library.\n"
-	"-S          Compile only; do not assemble or link.\n"
-        "-c          Compile and assemble, but do not link.\n"
-        "-save-temps Do not delete intermediate files.\n",
+        "-h --help    Display this information.\n"
+        "-v --version Display compiler version information.\n"
+        "-o <file>    Place the output into <file>.\n"
+        "-L<dir>      Location of B library.\n"
+        "-S           Compile only; do not assemble or link.\n"
+        "-c           Compile and assemble, but do not link.\n"
+        "-save-temps  Do not delete intermediate files.\n",
         arg0
     );
 }
@@ -57,11 +57,11 @@ int main(int argc, char **argv)
 
     for(int i = 1; i < argc; i++)
     {
-        if(strcmp(argv[i], "--help") == 0) {
+        if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             help(argv[0]);
             return 0;
         }
-        else if(strcmp(argv[i], "--version") == 0) {
+        else if(strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0) {
             version(argv[0]);
             return 0;
         }

--- a/src/libb/libb.c
+++ b/src/libb/libb.c
@@ -229,19 +229,19 @@ void B_FN(ctime)(B_TYPE time_vec, B_TYPE date) {
 
     date_vec[0] = month_strs[month][0];
     date_vec[1] = month_strs[month][1];
-    date_vec[3] = month_strs[month][2];
-    date_vec[4] = ' ';
-    date_vec[5] = day / 10 + '0';
-    date_vec[6] = day % 10 + '0';
-    date_vec[7] = ' ';
-    date_vec[8] = hour / 10 + '0';
-    date_vec[9] = hour % 10 + '0';
-    date_vec[10] = ':';
-    date_vec[11] = minute / 10 + '0';
-    date_vec[12] = minute % 10 + '0';
-    date_vec[13] = ':';
-    date_vec[14] = second / 10 + '0';
-    date_vec[15] = second % 10 + '0';
+    date_vec[2] = month_strs[month][2];
+    date_vec[3] = ' ';
+    date_vec[4] = day / 10 + '0';
+    date_vec[5] = day % 10 + '0';
+    date_vec[6] = ' ';
+    date_vec[7] = hour / 10 + '0';
+    date_vec[8] = hour % 10 + '0';
+    date_vec[9] = ':';
+    date_vec[10] = minute / 10 + '0';
+    date_vec[11] = minute % 10 + '0';
+    date_vec[12] = ':';
+    date_vec[13] = second / 10 + '0';
+    date_vec[14] = second % 10 + '0';
 }
 
 /* The current process is replaced by the execution of the


### PR DESCRIPTION
Changes:
- Allow using shorter `-h` and `-v` flags.
- Display file name and line number in compiler errors.
- Throw a proper error if it cannot open a file.
- Fix libb's `ctime` buffer being offset by 1.